### PR TITLE
have shippable test using the current lts and latest node versions

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "4.6.0"
-  - "6.7.0"
+  - "6.9.4"
+  - "7.4.0"
 
 script: npm test


### PR DESCRIPTION
nodejs has released some new versions since we set up the continuous integration 